### PR TITLE
Add table creation script

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,4 +57,9 @@ if __name__ == '__main__':
 
     # Usar eventlet para un servidor de WebSockets más robusto
     # allow_unsafe_werkzeug=True solo para desarrollo
-    socketio.run(app, host='0.0.0.0', port=5000, debug=True, allow_unsafe_werkzeug=True)
+socketio.run(app, host='0.0.0.0', port=5000, debug=True, allow_unsafe_werkzeug=True)
+
+import os
+
+if os.environ.get("RENDER", "") == "true":
+    from create_tables import *  # Ejecuta la creación de tablas al iniciar en Render

--- a/create_tables.py
+++ b/create_tables.py
@@ -1,0 +1,8 @@
+from app import create_app
+from models import db, User
+
+app, _ = create_app()
+
+with app.app_context():
+    db.create_all()
+    print("🎉 Tablas creadas.")


### PR DESCRIPTION
## Summary
- add a `create_tables.py` helper script to initialize the database
- run this script automatically on Render environments

## Testing
- `python -m py_compile create_tables.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846702cfe3083268edb83fb6736f825